### PR TITLE
Default to disc/track no. 1 if beefweb does not return number and move print volume into try

### DIFF
--- a/beefweb_mpris/adapter.py
+++ b/beefweb_mpris/adapter.py
@@ -30,8 +30,8 @@ class BeefwebAdapter(MprisAdapter):
                 artists=[columns.artists],
                 album=columns.album,
                 album_artists=[columns.album_artist],
-                disc_no=int(columns.disc_no),
-                track_no=int(columns.track_no)
+                disc_no=int(columns.disc_no) if columns.disc_no.isdigit() else 1,
+                track_no=int(columns.track_no) if columns.track_no.isdigit() else 1
             )
         except AttributeError as e:
             return MetadataObj(
@@ -151,8 +151,8 @@ class BeefwebAdapter(MprisAdapter):
         return f'file://{GLib.get_user_cache_dir()}/beefweb_mpris/{self.beefweb.active_item.columns.album}'
 
     def get_volume(self) -> VolumeDecimal:
-        print("returning volume: ", self.beefweb.state.volume.value)
         try:
+            print("returning volume: ", self.beefweb.state.volume.value)
             return self.beefweb.state.volume.value + 100.0
         except AttributeError:
             return 100


### PR DESCRIPTION
This PR brings in two small fixes.

The first looks if the disc_no and track_no are actually a number via isdigit(). Depending on what you're playing, for example modtracker music, it's possible that disc_no and track_no would return ?. On DEs like KDE it would then show no metadata information. If this happens, then the metadata just defaults to 1 to keep it in line.

The second fix just moves the print of returning volume to the try clause. It's possible that when beefweb doesn't return the volume quick enough at boot, it just kills off the whole mpris server with AttributeError.