### PR TITLE
Update interface schema to 0.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,6 @@
-aiohappyeyeballs==2.3.4; python_version >= '3.8' and python_version < '4.0'
-aiohttp==3.10.0; python_version >= '3.8'
-aiohttp-sse-client==0.2.1
-aiosignal==1.3.1; python_version >= '3.7'
-attrs==23.2.0; python_version >= '3.7'
-certifi==2024.7.4; python_version >= '3.6'
-charset-normalizer==3.3.2; python_full_version >= '3.7.0'
-emoji==1.7.0
-frozenlist==1.4.1; python_version >= '3.8'
-idna==3.7; python_version >= '3.5'
-mpris-server==0.4.2; python_version >= '3.7'
-multidict==6.0.5; python_version >= '3.7'
-pycairo==1.26.1; python_version >= '3.8'
-pydbus==0.6.0
-pyfoobeef==0.9.0.4; python_version >= '3.6'
-pygobject==3.48.2; python_version >= '3.8' and python_version < '4'
-pygobject-stubs==2.11.0; python_version >= '3.7'
-pyyaml==6.0.1; python_version >= '3.6'
-requests==2.32.3; python_version >= '3.8'
-unidecode==1.3.8; python_version >= '3.5'
-urllib3==2.2.2; python_version >= '3.8'
-yarl==1.9.4; python_version >= '3.7'
+mpris_server>=0.9
+pyfoobeef
+pyyaml
+pygobject
+pygobject-stubs
+requests


### PR DESCRIPTION
and comment out pass functions that are the same as the fallback adapter and implement some more functions
and remove unneeded imports and libraries
and bump version

The metadata stuff still never gets called on my KDE desktop, but the media control buttons are working now.

Also, I think only direct dependencies should be listed in requirements, since the packages we actually rely on could drop any of these dependencies at any moment.