### PR TITLE
Add desktop entry to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /beefweb_mpris.egg-info/
 /.idea/
+__pycache__/

--- a/beefweb_mpris/adapter.py
+++ b/beefweb_mpris/adapter.py
@@ -5,7 +5,7 @@ from math import log
 from mpris_server import MetadataObj, ValidMetadata
 from mpris_server.adapters import MprisAdapter
 from mpris_server.base import Microseconds, PlayState, DbusObj, DEFAULT_RATE, RateDecimal, VolumeDecimal, Track, \
-    DEFAULT_TRACK_ID
+    DEFAULT_TRACK_ID, Paths
 from mpris_server.mpris.compat import get_track_id
 from gi.repository import GLib
 
@@ -13,9 +13,13 @@ from beefweb_mpris.beefweb import Beefweb
 
 
 class BeefwebAdapter(MprisAdapter):
-    def __init__(self, wrapper: Beefweb):
+    def __init__(self, wrapper: Beefweb, desktop_entry: Paths):
         self.beefweb = wrapper
+        self.desktop_entry = desktop_entry
         super().__init__()
+
+    def get_desktop_entry(self) -> Paths:
+        return self.desktop_entry
 
     def metadata(self) -> ValidMetadata:
         try:

--- a/beefweb_mpris/main.py
+++ b/beefweb_mpris/main.py
@@ -23,6 +23,7 @@ def main():
             'host': 'localhost',
             'port': 8880,
             'foobar2000-command': 'foobar2000',
+            'desktop-entry': 'foobar2000',
             'username': 'user',
             'password': 'password'
         }
@@ -37,7 +38,7 @@ def main():
 
     foobar2000 = Popen([config['foobar2000-command']])
     beefweb = Beefweb(config['host'], config['port'], config['username'], config['password'])
-    adapter = BeefwebAdapter(beefweb)
+    adapter = BeefwebAdapter(beefweb, config['desktop-entry'])
     mpris = Server('beefweb', adapter=adapter)
 
     mpris_thread = threading.Thread(target=mpris.loop, daemon=True)


### PR DESCRIPTION
Previously, the MPRIS notification on Ubuntu showed as:

![image](https://github.com/user-attachments/assets/4a7c52d9-cfe6-4b3c-b53d-11f9eae83de2)

By configuring the desktop entry we can make it link to foobar2000, which means you can click the notification to open foobar2000 and it has a nice icon in the notification:

![image](https://github.com/user-attachments/assets/af1d6933-8c4e-40b6-8241-661235541b76)

Fixes #15