### PR TITLE
Added authentication in request for downloading art

### DIFF
--- a/beefweb_mpris/beefweb.py
+++ b/beefweb_mpris/beefweb.py
@@ -12,6 +12,8 @@ class Beefweb:
     def __init__(self, server: str, port: int, username: str, password: str):
         self.server = server
         self.port = port
+        self.username = username
+        self.password = password
         self.event_listener = pyfoobeef.EventListener(
             base_url=server,
             port=port,
@@ -48,8 +50,11 @@ class Beefweb:
 
     def download_art(self):
         try:
-            r = requests.get(f'http://{self.server}:{self.port}/api'
-                f'/artwork/{self.active_item.playlist_id}/{self.active_item.index}')
+            r = requests.get(
+                f'http://{self.server}:{self.port}/api/artwork/'
+                f'{self.active_item.playlist_id}/{self.active_item.index}',
+                auth=(self.username, self.password)
+                )
             cover_path = f'{GLib.get_user_cache_dir()}/beefweb_mpris/{self.active_item.columns.album}'
             if not os.path.isfile(cover_path):
                 if not os.path.isdir(os.path.dirname(cover_path)):


### PR DESCRIPTION
Changed the `get` request in `download_art` to include an `auth` parameter.

Without it, if you have enabled credentials on your beefweb interface, you can't actually download the artwork.

## Before
config.yaml and the foobar2000 settings (obscured for obvious reasons):
<img width="705" height="238" alt="image" src="https://github.com/user-attachments/assets/2c8683fb-e530-493f-b0fe-edf10dede32e" />

```
[yimche: ~/.cache/beefweb_mpris] playerctl metadata
beefweb mpris:trackid             '/track/Okay'
beefweb mpris:length              216280000
beefweb mpris:artUrl              file:///home/yimche/.cache/beefweb_mpris/okay.
beefweb xesam:title               Okay
...
```
<img width="1425" height="168" alt="image" src="https://github.com/user-attachments/assets/e62263a9-2115-406b-9c2b-ce6617997af2" />

